### PR TITLE
Add multifile torrent download capabilities

### DIFF
--- a/fileinfo/fileinfo.go
+++ b/fileinfo/fileinfo.go
@@ -1,0 +1,52 @@
+package fileinfo
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type FileInfo struct {
+	Length int      `bencode:"length"`
+	Path   []string `bencode:"path"`
+}
+
+func (file *FileInfo) WriteToDisk(buf []byte, files []FileInfo, path, torrentName string) error {
+	outputPath := createPath(path, torrentName, file.Path[0], files)
+
+	err := os.MkdirAll(filepath.Dir(outputPath), os.ModePerm)
+	if err != nil {
+		return err
+	}
+
+	fileBuf := make([]byte, file.Length)
+	copy(fileBuf, buf[getOffset(*file, files):getOffset(*file, files)+file.Length])
+
+	err = os.WriteFile(outputPath, fileBuf, os.ModePerm)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("saved file %s\n", file.Path[0])
+
+	return nil
+}
+
+func getOffset(file FileInfo, files []FileInfo) int {
+	offset := 0
+	for _, f := range files {
+		if f.Length == file.Length && f.Path[0] == file.Path[0] {
+			return offset
+		}
+		offset += f.Length
+	}
+	return -1
+}
+
+func createPath(path, torrentName, filename string, files []FileInfo) (outputPath string) {
+	if len(files) < 2 {
+		return filepath.Join(path, torrentName)
+	}
+
+	return filepath.Join(path, torrentName, filename)
+}

--- a/fileinfo/fileinfo_test.go
+++ b/fileinfo/fileinfo_test.go
@@ -1,0 +1,44 @@
+package fileinfo
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreatePathSingleFileTorrent(t *testing.T) {
+	files := []FileInfo{
+		{
+			Path:   []string{"archlinux-2019.12.01-x86_64.iso"},
+			Length: 1,
+		},
+	}
+
+	want := "test/archlinux-2019.12.01-x86_64.iso"
+	got := createPath("test", files[0].Path[0], "archlinux-2019.12.01-x86_64.iso", files)
+
+	assert.Equal(t, want, got)
+}
+
+func TestCreatePathMultiFileTorrent(t *testing.T) {
+	files := []FileInfo{
+		{
+			Path:   []string{"archlinux-2019.12.01-x86_64.iso"},
+			Length: 1,
+		},
+		{
+			Path:   []string{"sali.txt"},
+			Length: 1,
+		},
+	}
+
+	givenPath := "dir1"
+	torrentName := "dir2"
+
+	for _, file := range files {
+		want := fmt.Sprintf("%s/%s/%s", givenPath, torrentName, file.Path[0])
+		got := createPath(givenPath, torrentName, file.Path[0], files)
+		assert.Equal(t, want, got)
+	}
+}


### PR DESCRIPTION
Support downloading multi-file torrents concurrently and efficiently handle fetching and uploading pieces of blocks to and from peers. Also unit test the functionality with new changes.
